### PR TITLE
MILAB-6263: fix renv runtime permission-denied on non-root containers (parse-seurat)

### DIFF
--- a/.changeset/fix-runtime-renv-restore-permission-denied.md
+++ b/.changeset/fix-runtime-renv-restore-permission-denied.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.samples-and-data.parse-seurat": patch
+---
+
+Fix runtime `Permission denied` when the parse-seurat container runs as a non-root UID (MILAB-6263). The entrypoint re-invoked `renv::restore()` on every start, which tries to reconcile the system R library at `/usr/local/lib/R/site-library/` with the project lockfile. When the `r-base:4.4.2` base image preinstalled a version of a locked package (e.g. `rlang`) that differs from `renv.lock`, renv attempted to back up the system-library copy before replacing it — failing on hosts that run the container unprivileged. renv now installs into a project-local library at `/app/renv/library` and `R_LIBS_USER` points R at the same path, so the obsolete `/app/run.sh` wrapper and runtime restore are removed.

--- a/software/parse-seurat/Dockerfile
+++ b/software/parse-seurat/Dockerfile
@@ -8,6 +8,9 @@ ENV RENV_CONFIG_REPOS_OVERRIDE=https://cloud.r-project.org
 
 # Install system dependencies required for R packages
 RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    dash \
     libcurl4-openssl-dev \
     libssl-dev \
     libxml2-dev \
@@ -29,6 +32,7 @@ RUN apt-get update && apt-get install -y \
     libbz2-dev \
     liblzma-dev \
     libpcre2-dev \
+    libuv1-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -56,6 +60,9 @@ ENV RENV_PATHS_LIBRARY=${R_LIBS_USER}
 # Yes, we have to create it manually. Otherwise default will be used silently.
 RUN mkdir -p "${R_LIBS_USER}"
 
-RUN R --no-echo -e "renv::restore(clean = TRUE)" \
+# First pass: parallel install (fast for the bulk of packages).
+# Second pass: sequential retry to resolve any parallel-install races
+# (e.g. ggplot2 starting before tibble is visible in the library).
+RUN R --no-echo -e "tryCatch(renv::restore(), error = function(e) message('parallel pass finished with errors: ', conditionMessage(e))); options(Ncpus = 1); renv::restore(clean = TRUE)" \
     && find /root/.cache/R -name keys.html -delete \
     && find /usr/local/lib/R -name keys.html -delete

--- a/software/parse-seurat/Dockerfile
+++ b/software/parse-seurat/Dockerfile
@@ -47,12 +47,15 @@ COPY ./renv.lock ./renv.lock
 ENV RENV_PATHS_RENV=/app/renv
 ENV RENV_PATHS_LOCKFILE=/app/renv.lock
 
+# Direct renv to install into a project-local library (instead of the
+# system-wide /usr/local/lib/R/site-library) and expose that path to R via
+# R_LIBS_USER so Rscript finds the packages at runtime without any renv code.
+ENV R_LIBS_USER=/app/renv/library
+ENV RENV_PATHS_LIBRARY=${R_LIBS_USER}
+
+# Yes, we have to create it manually. Otherwise default will be used silently.
+RUN mkdir -p "${R_LIBS_USER}"
+
 RUN R --no-echo -e "renv::restore(clean = TRUE)" \
     && find /root/.cache/R -name keys.html -delete \
     && find /usr/local/lib/R -name keys.html -delete
-
-RUN echo "#!/bin/bash\nR --no-echo --no-restore -e \"renv::restore()\"\n\"\$@\"" > /app/run.sh
-RUN chmod +x /app/run.sh
-
-# Default command runs Rscript
-ENTRYPOINT ["/app/run.sh"]

--- a/software/parse-seurat/Dockerfile
+++ b/software/parse-seurat/Dockerfile
@@ -8,31 +8,31 @@ ENV RENV_CONFIG_REPOS_OVERRIDE=https://cloud.r-project.org
 
 # Install system dependencies required for R packages
 RUN apt-get update && apt-get install -y \
-    curl \
     ca-certificates \
+    curl \
     dash \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    libxml2-dev \
-    libcairo2-dev \
-    libgit2-dev \
     default-libmysqlclient-dev \
+    libbz2-dev \
+    libcairo2-dev \
+    libcurl4-openssl-dev \
+    libfreetype6-dev \
+    libfribidi-dev \
+    libgit2-dev \
+    libgsl-dev \
+    libharfbuzz-dev \
+    libjpeg-dev \
+    liblzma-dev \
+    libpcre2-dev \
+    libpng-dev \
     libpq-dev \
     libsasl2-dev \
     libsqlite3-dev \
     libssh2-1-dev \
-    unixodbc-dev \
-    libharfbuzz-dev \
-    libfribidi-dev \
-    libfreetype6-dev \
-    libpng-dev \
+    libssl-dev \
     libtiff5-dev \
-    libjpeg-dev \
-    libgsl-dev \
-    libbz2-dev \
-    liblzma-dev \
-    libpcre2-dev \
     libuv1-dev \
+    libxml2-dev \
+    unixodbc-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -65,4 +65,5 @@ RUN mkdir -p "${R_LIBS_USER}"
 # (e.g. ggplot2 starting before tibble is visible in the library).
 RUN R --no-echo -e "tryCatch(renv::restore(), error = function(e) message('parallel pass finished with errors: ', conditionMessage(e))); options(Ncpus = 1); renv::restore(clean = TRUE)" \
     && find /root/.cache/R -name keys.html -delete \
-    && find /usr/local/lib/R -name keys.html -delete
+    && find /usr/local/lib/R -name keys.html -delete \
+    && find "${R_LIBS_USER}" -name keys.html -delete


### PR DESCRIPTION
## Summary
Cross-block fix: the docker entrypoint of the parse-seurat R software re-ran `renv::restore()` on every container start. On hosts that run the container as a non-root UID (e.g. lab.research), renv tried to back up entries in the root-owned `/usr/local/lib/R/site-library/` (e.g. `rlang` brought in by the `r-base:4.4.2` base image) and failed with `Permission denied`.

Already merged in `differential-clonotype-abundance` (platforma-open/differential-clonotype-abundance#43); the same `Dockerfile` pattern was replicated here. Affects the `parse-seurat` entrypoint only; `parse-h5ad` uses a Python-based image and isn't impacted.

## Change
- `ENV R_LIBS_USER=/app/renv/library` + `ENV RENV_PATHS_LIBRARY=\${R_LIBS_USER}` so renv installs into a project-local library and R discovers packages via the standard `R_LIBS_USER` env var.
- `RUN mkdir -p \"\${R_LIBS_USER}\"` because renv silently falls back to the default library if the path doesn't exist.
- Drop `/app/run.sh` and the `ENTRYPOINT`; the platforma SDK passes the full `cmd` (`Rscript /app/...`) at run time, so no wrapper is needed.

## Test plan
- [ ] CI build of the docker image succeeds.
- [ ] On a non-root host (lab.research), running the parse-seurat entrypoint no longer logs `cannot create directory '/usr/local/lib/R/site-library/...': Permission denied`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `Permission denied` error in `parse-seurat` that occurred when renv's runtime `renv::restore()` call tried to back up root-owned system library entries on hosts running the container as a non-root UID. The fix redirects renv to a project-local library (`/app/renv/library`) at build time and removes the runtime restore wrapper entirely.

- Sets `R_LIBS_USER=/app/renv/library` and `RENV_PATHS_LIBRARY=${R_LIBS_USER}` so packages are installed into and resolved from `/app/renv/library` — owned by root at build time and never written to at runtime.
- Pre-creates the directory with `mkdir -p` to prevent renv from silently falling back to the system library if the path is absent.
- Drops `/app/run.sh` and the `ENTRYPOINT`, relying on the platforma SDK to supply the full `Rscript` command at run time.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix correctly moves package installation to build time and removes the root-owned library write at runtime.

The approach — setting `R_LIBS_USER` and `RENV_PATHS_LIBRARY` to a build-time-created directory and removing the runtime `renv::restore()` wrapper — is sound and mirrors the already-merged fix in `differential-clonotype-abundance`. The only open item is a missing trailing newline in the Dockerfile, which has no functional impact.

No files require special attention beyond the minor trailing-newline in `software/parse-seurat/Dockerfile`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| software/parse-seurat/Dockerfile | Redirects renv library to project-local `/app/renv/library`, removes the runtime `run.sh` wrapper and ENTRYPOINT; the fix is logically sound but the Dockerfile is missing a trailing newline. |
| .changeset/fix-runtime-renv-restore-permission-denied.md | New changeset entry describing the patch; content is accurate and matches the Dockerfile changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Docker build starts\n(r-base:4.4.2)"] --> B["Install system deps\n(apt-get)"]
    B --> C["Install renv\n(R install.packages)"]
    C --> D["COPY *.R + renv.lock"]
    D --> E["Set ENV vars\nRENV_PATHS_RENV=/app/renv\nRENV_PATHS_LOCKFILE=/app/renv.lock\nR_LIBS_USER=/app/renv/library\nRENV_PATHS_LIBRARY=/app/renv/library"]
    E --> F["mkdir -p /app/renv/library"]
    F --> G["renv::restore(clean=TRUE)\n→ installs into /app/renv/library"]
    G --> H["Cleanup keys.html artefacts"]
    H --> I["Image ready — no ENTRYPOINT"]
    I --> J["Runtime: platforma SDK\nprovides full cmd\nRscript /app/..."]
    J --> K["R resolves packages via\nR_LIBS_USER=/app/renv/library\n(no renv::restore at runtime)"]
    style E fill:#d4edda
    style G fill:#d4edda
    style J fill:#cce5ff
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
software/parse-seurat/Dockerfile:61
The Dockerfile is missing a trailing newline. This is a minor style issue but some tools (e.g., `diff`, linters) warn about files that don't end with a newline.

```suggestion
    && find /usr/local/lib/R -name keys.html -delete
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6263: Dockerfile + changeset"](https://github.com/platforma-open/samples-and-data/commit/36f445816c0fcb9d803271b26ff4aab4b3d30109) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31762674)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->