### PR TITLE
MILAB-6274: fix samplesheet metadata import + auto-bind BarcodeID column

### DIFF
--- a/.changeset/MILAB-6274_minimum-fix.md
+++ b/.changeset/MILAB-6274_minimum-fix.md
@@ -1,0 +1,9 @@
+---
+"@platforma-open/milaboratories.samples-and-data.ui": patch
+---
+
+Fix samplesheet metadata import on `MultiplexedFastq` datasets (MILAB-6274). The import dialog no longer auto-binds every non-File / non-Sample column as a barcode tag — that bug silently dropped metadata columns like `Condition` and `Treatment`. Auto-bind now restricts to columns whose header matches an already-declared tag (case-insensitive substring); unmatched columns flow through the metadata pipeline.
+
+On a fresh `MultiplexedFastq` dataset with no declared tags, the dialog auto-binds any column whose header contains `barcode` (case-insensitive) as a `BarcodeID` tag. This restores end-to-end compatibility with Miltenyi clonotyping and other demultiplex blocks: operators get one rule per sample without manually authoring tags, the dataset's `multiplexingRules` column emits, and the downstream block runs cleanly.
+
+Zero-binding imports (metadata-only samplesheets on fresh datasets) are now allowed.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.1
     '@platforma-sdk/block-tools':
-      specifier: 2.7.15
-      version: 2.7.15
+      specifier: 2.8.1
+      version: 2.8.1
     '@platforma-sdk/blocks-deps-updater':
       specifier: 2.2.0
       version: 2.2.0
@@ -131,7 +131,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.15
+        version: 2.8.1
 
   model:
     dependencies:
@@ -144,7 +144,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.15
+        version: 2.8.1
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.37.0)(@stylistic/eslint-plugin@2.13.0(eslint@9.37.0)(typescript@5.6.3))(eslint-plugin-n@17.23.1(eslint@9.37.0)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.37.0))(eslint@9.37.0)(globals@15.15.0)(typescript-eslint@8.46.0(eslint@9.37.0)(typescript@5.6.3))(typescript@5.6.3)
@@ -898,6 +898,10 @@ packages:
     resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
     engines: {node: '>=22'}
 
+  '@milaboratories/helpers@1.14.2':
+    resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
+    engines: {node: '>=22'}
+
   '@milaboratories/pf-driver@1.3.5':
     resolution: {integrity: sha512-wYPERfpDqEP9Y/cGaHBpvodE6qCgn8Fpc8GZP+u5f8Cu2rEI3wYCYY9Cvh2APSXgxeekglHdRPxusucibD/rqA==}
     engines: {node: '>=22.19.0'}
@@ -923,6 +927,10 @@ packages:
     resolution: {integrity: sha512-2h9PiaDUneZT6ieNnlet8A8HrwntUxJwxDmivXvXUEbiEStvsLnnrytkyYWMRS2PdwMrqbujZACyKbcdkOBMLQ==}
     engines: {node: '>=22.19.0'}
 
+  '@milaboratories/pl-client@3.8.0':
+    resolution: {integrity: sha512-ADUFHvwtGDC/sOYd4btCw2GdR58gq3+Nm9yV3UUYhmH5dv3J/1tXsxJH15mv1mT9YvK0IS4vMw0eDteeQUmaiQ==}
+    engines: {node: '>=22.19.0'}
+
   '@milaboratories/pl-config@1.7.17':
     resolution: {integrity: sha512-qqpgWAvKP/nL7GC9oBnAXLJwuib4johKqgKIrTkqiQE14B/HwjLebSAKTQUx9ya2/nDBZyjJbHeXvkmoWyqwrw==}
 
@@ -933,6 +941,9 @@ packages:
   '@milaboratories/pl-drivers@1.12.11':
     resolution: {integrity: sha512-PM236fhhJR4Jiad8bqY1OSoRVtVwIajSQfvRl74j4aTYD+f4y/dhR5zOiu/uTBA+S0b/rjzIKFqHCGGI5Aujag==}
     engines: {node: '>=22'}
+
+  '@milaboratories/pl-error-like@1.12.10':
+    resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
   '@milaboratories/pl-error-like@1.12.9':
     resolution: {integrity: sha512-9qlfawLFO4qG656ayvVSRholhhwlfXUvKKllXpHadqbnf2zO2oCd+5J76bPaFXDz/A3T+1eokCnCX74JsqCYSw==}
@@ -950,14 +961,17 @@ packages:
   '@milaboratories/pl-model-backend@1.2.8':
     resolution: {integrity: sha512-bIzTeSowEuSHENqb9x5Ypf0SIw3ed+B6JfvQU5Udf12yQFDmNsyJ9sVylSnLbNzUkTVtuj7e9FomySOH8XZkQg==}
 
+  '@milaboratories/pl-model-backend@1.3.1':
+    resolution: {integrity: sha512-zDWTa/AqI2YSmD3FpQavWI9OnZzMRoNQS+E8YtdSadC9LkvetqY5YI9Uu/IAGrWVonlvjD6uA0PrPX5hACOxow==}
+
   '@milaboratories/pl-model-common@1.28.0':
     resolution: {integrity: sha512-VGfXSzep5LR8vnj7El0ksDiZEmELhT8jB7EeXv3VIOmYZj4cPYbkNsb+54wrBloMzyIc1iG1H13ucR44qbv/bw==}
 
   '@milaboratories/pl-model-common@1.31.2':
     resolution: {integrity: sha512-dnK0zXzylN7MAO1Nyx8EJargaqa94iDDEDwZW7d1/lRl1p50cR9zGP8pUnIy1I8UcI4lzH34f81RRQy6AbTuTw==}
 
-  '@milaboratories/pl-model-common@1.36.1':
-    resolution: {integrity: sha512-2s2UAcL0fvdSWYKGO4sE7hqAmAr1OANE6DLgt0gooe/368KzH+eybSyuvB/h+7yaRKkgaBsZP0rPVPddIsoXOQ==}
+  '@milaboratories/pl-model-common@1.42.0':
+    resolution: {integrity: sha512-ttX9OcQ9kgEhgyXZNkC7+vtsCaxjz+uNwmU8d2LlA56cpWgWV9WONi91w8nCRGFf9WboSgUVVaFj2XxiT9QHXQ==}
 
   '@milaboratories/pl-model-middle-layer@1.15.0':
     resolution: {integrity: sha512-uYb/H+rYWSY4IckYxKClQF6yLv+yOJMqtIfJusd7MuCn29HYeQLMruowNaf9A/O35bFx5gqAeiF7XDCn2iQHNA==}
@@ -965,8 +979,8 @@ packages:
   '@milaboratories/pl-model-middle-layer@1.16.4':
     resolution: {integrity: sha512-uFTZHEjRmfRvY97tRbBuTvNzQnTYIj58S8HBzyMsFkzxbUI8vTBPtvEqbTU2IbQ31IEGvv8T0BBl9b7/vdud0A==}
 
-  '@milaboratories/pl-model-middle-layer@1.18.6':
-    resolution: {integrity: sha512-kRX5TpkjWwnWwHXISjXr+FiYZIHzIq/6Qz7amn05HLkfPn+WOFuWdbmiQIuXU2Fwr5Nzcj6bp4SgQDI/BZYhDg==}
+  '@milaboratories/pl-model-middle-layer@1.20.0':
+    resolution: {integrity: sha512-RGEJD0avNEBejl1SjCqn7RWNiK15xCNWMXfNziiHUcG4n+QxYm1sk5AezfWsKE3j3y1HdzZnYaoGto9Z1RoV7A==}
 
   '@milaboratories/pl-tree@1.9.9':
     resolution: {integrity: sha512-WHeWAR8xAfobdpXBFJY5rBV6lPkpMrfWLiNAROozWp9S16EHFlauHS//ykcxyqwr438HLjkGurDCygbS5COvmQ==}
@@ -992,8 +1006,15 @@ packages:
   '@milaboratories/ts-helpers-oclif@1.1.40':
     resolution: {integrity: sha512-0I5vpgfUYT0sfADFTy5iVeCNPPBnJcZzd6enmbxYp2YczV1EdPDVhv+BbLIN3oLLMKpADJJ485QEXhN2i39Yvg==}
 
+  '@milaboratories/ts-helpers-oclif@1.1.41':
+    resolution: {integrity: sha512-rpn1jB2b6p4hcw4Y2iuLM/9X9zqGXacRL1RbZMaB6ebk+2bnmH3CtmfJJdBWW1wfsP80HqmRV8iQrfCI1kzFDA==}
+
   '@milaboratories/ts-helpers@1.8.1':
     resolution: {integrity: sha512-eIDBzT9quzL3T7ivQn2BCKlsCqnCoSjtMSWSyFmdzPyDAY2OXb6sBjcYcSDdYLQAn2BANBEevii2Tp+WYAzIQw==}
+    engines: {node: '>=22.19.0'}
+
+  '@milaboratories/ts-helpers@1.8.2':
+    resolution: {integrity: sha512-bQHcEAeJXyV95Gyk0yoRS5t3M71mFaNG+SsY2o+i4GDDeByUXBiF+T5A0elc/rCyLK6NNlOblou0DHBYOiW3pQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/uikit@2.12.2':
@@ -1115,12 +1136,12 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.0.4':
     resolution: {integrity: sha512-q8dAJ/RwAR35uKj74Bvzq4lpuBLxzuCNkuCH4suwb2ybDyEggL0XUB26aUuf15hX+6rFVulyBaQToXURKVKwzw==}
 
-  '@platforma-sdk/block-tools@2.7.15':
-    resolution: {integrity: sha512-aWsJt5MU7yYSR+X+OvQ7liuk+SAQBzqYBjMTgr+Klibv5anWQ0hdOdDWn4T7lwVBTGTvoFsUBMzjTq9fiSIIDA==}
-    hasBin: true
-
   '@platforma-sdk/block-tools@2.7.7':
     resolution: {integrity: sha512-pcepxZC9XpSRdKIzb5AarCwvzSqPcr38QJZFo34iQiZF4/fVyFtPLOxT/Lux5eYWGiE82dw0xok4xfO4s7AELA==}
+    hasBin: true
+
+  '@platforma-sdk/block-tools@2.8.1':
+    resolution: {integrity: sha512-5PA8iAdndsxlbk4YMAJDnueFBNracOHPDV8a6Zw10mkxP6+YFvsnlA4+kJoh7ULTgI6qPpLmCYwvPdA6KFwd7g==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -3825,6 +3846,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vite@6.2.3:
@@ -5127,6 +5149,8 @@ snapshots:
 
   '@milaboratories/helpers@1.14.1': {}
 
+  '@milaboratories/helpers@1.14.2': {}
+
   '@milaboratories/pf-driver@1.3.5(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.1
@@ -5195,6 +5219,24 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.1
 
+  '@milaboratories/pl-client@3.8.0':
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/ts-helpers': 1.8.2
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      canonicalize: 2.1.0
+      denque: 2.1.0
+      long: 5.3.2
+      lru-cache: 11.2.2
+      openapi-fetch: 0.15.0
+      undici: 7.16.0
+      utility-types: 3.11.0
+      yaml: 2.8.1
+
   '@milaboratories/pl-config@1.7.17':
     dependencies:
       '@milaboratories/ts-helpers': 1.8.1
@@ -5237,6 +5279,11 @@ snapshots:
     transitivePeerDependencies:
       - bare-buffer
       - supports-color
+
+  '@milaboratories/pl-error-like@1.12.10':
+    dependencies:
+      json-stringify-safe: 5.0.1
+      zod: 3.25.76
 
   '@milaboratories/pl-error-like@1.12.9':
     dependencies:
@@ -5297,6 +5344,12 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
+  '@milaboratories/pl-model-backend@1.3.1':
+    dependencies:
+      '@milaboratories/pl-client': 3.8.0
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
   '@milaboratories/pl-model-common@1.28.0':
     dependencies:
       '@milaboratories/helpers': 1.14.0
@@ -5311,10 +5364,10 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.36.1':
+  '@milaboratories/pl-model-common@1.42.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-error-like': 1.12.9
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -5334,10 +5387,10 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.18.6':
+  '@milaboratories/pl-model-middle-layer@1.20.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.36.1
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-model-common': 1.42.0
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76
@@ -5371,9 +5424,20 @@ snapshots:
       '@milaboratories/ts-helpers': 1.8.1
       '@oclif/core': 4.0.37
 
+  '@milaboratories/ts-helpers-oclif@1.1.41':
+    dependencies:
+      '@milaboratories/ts-helpers': 1.8.2
+      '@oclif/core': 4.0.37
+
   '@milaboratories/ts-helpers@1.8.1':
     dependencies:
       '@milaboratories/helpers': 1.14.1
+      canonicalize: 2.1.0
+      denque: 2.1.0
+
+  '@milaboratories/ts-helpers@1.8.2':
+    dependencies:
+      '@milaboratories/helpers': 1.14.2
       canonicalize: 2.1.0
       denque: 2.1.0
 
@@ -5592,12 +5656,12 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
-  '@platforma-sdk/block-tools@2.7.15':
+  '@platforma-sdk/block-tools@2.7.7':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.36.1
-      '@milaboratories/pl-model-middle-layer': 1.18.6
+      '@milaboratories/pl-model-common': 1.31.2
+      '@milaboratories/pl-model-middle-layer': 1.16.4
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.1
       '@milaboratories/ts-helpers-oclif': 1.1.40
@@ -5613,15 +5677,16 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/block-tools@2.7.7':
+  '@platforma-sdk/block-tools@2.8.1':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.31.2
-      '@milaboratories/pl-model-middle-layer': 1.16.4
+      '@milaboratories/pl-model-backend': 1.3.1
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.1
-      '@milaboratories/ts-helpers-oclif': 1.1.40
+      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/ts-helpers-oclif': 1.1.41
       '@oclif/core': 4.0.37
       '@platforma-sdk/blocks-deps-updater': 2.2.0
       canonicalize: 2.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 3.12.0
       version: 3.12.0
     '@platforma-sdk/tengo-builder':
-      specifier: 2.5.8
-      version: 2.5.8
+      specifier: 3.0.2
+      version: 3.0.2
     '@platforma-sdk/test':
       specifier: 1.65.2
       version: 1.65.2
@@ -278,7 +278,7 @@ importers:
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 2.5.8
+        version: 3.0.2
 
 packages:
 
@@ -931,6 +931,10 @@ packages:
     resolution: {integrity: sha512-ADUFHvwtGDC/sOYd4btCw2GdR58gq3+Nm9yV3UUYhmH5dv3J/1tXsxJH15mv1mT9YvK0IS4vMw0eDteeQUmaiQ==}
     engines: {node: '>=22.19.0'}
 
+  '@milaboratories/pl-client@3.8.1':
+    resolution: {integrity: sha512-x2Y1xooxtEttIfj60JSGMUDdTsAk3RrmlOmuuytwgq82RfDpAAa1M1XHBfuCUNoAjDP1e6BgU9rk4ZhOMGBf9A==}
+    engines: {node: '>=22.19.0'}
+
   '@milaboratories/pl-config@1.7.17':
     resolution: {integrity: sha512-qqpgWAvKP/nL7GC9oBnAXLJwuib4johKqgKIrTkqiQE14B/HwjLebSAKTQUx9ya2/nDBZyjJbHeXvkmoWyqwrw==}
 
@@ -963,6 +967,9 @@ packages:
 
   '@milaboratories/pl-model-backend@1.3.1':
     resolution: {integrity: sha512-zDWTa/AqI2YSmD3FpQavWI9OnZzMRoNQS+E8YtdSadC9LkvetqY5YI9Uu/IAGrWVonlvjD6uA0PrPX5hACOxow==}
+
+  '@milaboratories/pl-model-backend@1.3.2':
+    resolution: {integrity: sha512-1w4Jcl2vk7w8foWztKthDryQCPrkefW+5hXIwSNsNIB40o0v83p4zoqMGBrrm9b2MJUPoFyliTkAsp+J1UQu9g==}
 
   '@milaboratories/pl-model-common@1.28.0':
     resolution: {integrity: sha512-VGfXSzep5LR8vnj7El0ksDiZEmELhT8jB7EeXv3VIOmYZj4cPYbkNsb+54wrBloMzyIc1iG1H13ucR44qbv/bw==}
@@ -1170,8 +1177,8 @@ packages:
     resolution: {integrity: sha512-bId52YqV5iLDAn9D9C3xaLD1bKyymGpHe2CDEZTqV+1yWCBh1RM6iH96JIXudVJdcmJaqwJWDw6X4WzStE6SCg==}
     hasBin: true
 
-  '@platforma-sdk/tengo-builder@2.5.8':
-    resolution: {integrity: sha512-VztI3+WC8qc5tB2L8rX/RvbzNV/xMBJ5/yGCmKQ5BaIHMbtk/bJdPlBuasCcOkUo0PNNr0ivZt6vZGcUTxfvrA==}
+  '@platforma-sdk/tengo-builder@3.0.2':
+    resolution: {integrity: sha512-v1g1SOtZDrCuIcvrlqwsaf3stCHsrV8wuoOgl8ok67fX+9cJtT/QU6NIv+qfog0uukHEjHxourwcu+w0Moz6GQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -5237,6 +5244,24 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.1
 
+  '@milaboratories/pl-client@3.8.1':
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/ts-helpers': 1.8.2
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      canonicalize: 2.1.0
+      denque: 2.1.0
+      long: 5.3.2
+      lru-cache: 11.2.2
+      openapi-fetch: 0.15.0
+      undici: 7.16.0
+      utility-types: 3.11.0
+      yaml: 2.8.1
+
   '@milaboratories/pl-config@1.7.17':
     dependencies:
       '@milaboratories/ts-helpers': 1.8.1
@@ -5347,6 +5372,12 @@ snapshots:
   '@milaboratories/pl-model-backend@1.3.1':
     dependencies:
       '@milaboratories/pl-client': 3.8.0
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-backend@1.3.2':
+    dependencies:
+      '@milaboratories/pl-client': 3.8.1
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -5756,12 +5787,12 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/tengo-builder@2.5.8':
+  '@platforma-sdk/tengo-builder@3.0.2':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.2.8
+      '@milaboratories/pl-model-backend': 1.3.2
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
-      '@milaboratories/ts-helpers': 1.8.1
+      '@milaboratories/ts-helpers': 1.8.2
       '@oclif/core': 4.0.37
       winston: 3.17.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ packages:
   - test
 
 catalog:
-  '@platforma-sdk/block-tools': 2.7.15
+  '@platforma-sdk/block-tools': 2.8.1
   '@platforma-sdk/model': 1.65.4
   '@platforma-sdk/ui-vue': 1.65.4
   '@platforma-sdk/tengo-builder': 2.5.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalog:
   '@platforma-sdk/block-tools': 2.8.1
   '@platforma-sdk/model': 1.65.4
   '@platforma-sdk/ui-vue': 1.65.4
-  '@platforma-sdk/tengo-builder': 2.5.8
+  '@platforma-sdk/tengo-builder': 3.0.2
   '@platforma-sdk/workflow-tengo': 5.13.3
   "@platforma-sdk/blocks-deps-updater": 2.2.0
   "@platforma-sdk/eslint-config": ^1.2.0

--- a/test/src/wf.test.ts
+++ b/test/src/wf.test.ts
@@ -375,3 +375,89 @@ blockTest('simple multiplexed fastq input', async ({ rawPrj: project, ml: _ml, h
     sampleGroups: { ok: true, value: { } },
   });
 });
+
+blockTest('multiplexed fastq with barcode rules', async ({ rawPrj: project, ml: _ml, helpers, expect }) => {
+  const blockId = await project.addBlock('Block', blockSpec);
+  const sample1Id = uniquePlId();
+  const sample2Id = uniquePlId();
+  const metaColumn1Id = uniquePlId();
+  const dataset1Id = uniquePlId();
+  const group1Id = uniquePlId();
+
+  const r1Handle = await helpers.getLocalFileHandle('./assets/small_data_R1.fastq.gz');
+  const r2Handle = await helpers.getLocalFileHandle('./assets/small_data_R2.fastq.gz');
+
+  await project.mutateBlockStorage(blockId, { operation: 'update-block-data', value: {
+    metadata: [
+      {
+        id: metaColumn1Id,
+        label: 'Condition',
+        global: false,
+        valueType: 'String',
+        data: {
+          [sample1Id]: 'Healthy',
+          [sample2Id]: 'Disease',
+        },
+      },
+    ],
+    sampleIds: [sample1Id, sample2Id],
+    sampleLabelColumnLabel: 'Sample Name',
+    sampleLabels: {
+      [sample1Id]: 'sampleC',
+      [sample2Id]: 'sampleD',
+    },
+    datasets: [
+      {
+        id: dataset1Id,
+        label: 'Dataset 1',
+        content: {
+          type: 'MultiplexedFastq',
+          readIndices: ['R1', 'R2'],
+          gzipped: true,
+          groupLabels: {
+            [group1Id]: 'Group 1',
+          },
+          sampleGroups: {
+            [group1Id]: {
+              [sample1Id]: 'sampleC',
+              [sample2Id]: 'sampleD',
+            },
+          },
+          data: {
+            [group1Id]: {
+              R1: r1Handle,
+              R2: r2Handle,
+            },
+          },
+          barcodeTags: ['BarcodeID'],
+          barcodeRules: [
+            {
+              ruleId: 'rule-1',
+              sampleGroupId: group1Id,
+              sampleId: sample1Id,
+              barcodes: { BarcodeID: 'UDP0001' },
+            },
+            {
+              ruleId: 'rule-2',
+              sampleGroupId: group1Id,
+              sampleId: sample2Id,
+              barcodes: { BarcodeID: 'UDP0002' },
+            },
+          ],
+        },
+      },
+    ],
+    h5adFilesToPreprocess: [],
+    seuratFilesToPreprocess: [],
+    suggestedImport: false,
+  } satisfies BlockData });
+  await project.runBlock(blockId);
+  await helpers.awaitBlockDone(blockId);
+  const blockState = project.getBlockState(blockId);
+  const stableState = await blockState.awaitStableValue();
+
+  expect(stableState.outputs).toMatchObject({
+    fileImports: { ok: true, value: { [r1Handle]: { done: true }, [r2Handle]: { done: true } } },
+    sampleGroups: { ok: true, value: { } },
+  });
+});

--- a/test/src/wf.test.ts
+++ b/test/src/wf.test.ts
@@ -3,7 +3,7 @@ import { uniquePlId } from '@platforma-sdk/model';
 import { blockTest } from '@platforma-sdk/test';
 import { blockSpec } from 'this-block';
 
-blockTest('empty inputs', { timeout: 30000 }, async ({ rawPrj: project, ml, helpers, expect }) => {
+blockTest('empty inputs', { timeout: 30000 }, async ({ rawPrj: project, helpers, expect }) => {
   const blockId = await project.addBlock('Block', blockSpec);
   await project.runBlock(blockId);
   await helpers.awaitBlockDone(blockId);
@@ -19,7 +19,7 @@ blockTest('empty inputs', { timeout: 30000 }, async ({ rawPrj: project, ml, help
   });
 });
 
-blockTest('simple input', async ({ rawPrj: project, ml, helpers, expect }) => {
+blockTest('simple input', async ({ rawPrj: project, helpers, expect }) => {
   const blockId = await project.addBlock('Block', blockSpec);
   const sample1Id = uniquePlId();
   const metaColumn1Id = uniquePlId();
@@ -75,7 +75,7 @@ blockTest('simple input', async ({ rawPrj: project, ml, helpers, expect }) => {
   });
 });
 
-blockTest('simple multilane input', async ({ rawPrj: project, ml, helpers, expect }) => {
+blockTest('simple multilane input', async ({ rawPrj: project, helpers, expect }) => {
   const blockId = await project.addBlock('Block', blockSpec);
   const sample1Id = uniquePlId();
   const metaColumn1Id = uniquePlId();
@@ -376,6 +376,12 @@ blockTest('simple multiplexed fastq input', async ({ rawPrj: project, ml: _ml, h
   });
 });
 
+// Regression net for the rules-present MultiplexedFastq emission path.
+// PR #124's `defaultBindingsFor` changes (skip non-matching headers +
+// barcode-shaped fallback) both seed datasets shaped like this one. The
+// block must reach stable state with populated `barcodeRules` + `barcodeTags`
+// and import both reads. Sibling test 'simple multiplexed fastq input'
+// above exercises the zero-rules path.
 blockTest('multiplexed fastq with barcode rules', async ({ rawPrj: project, ml: _ml, helpers, expect }) => {
   const blockId = await project.addBlock('Block', blockSpec);
   const sample1Id = uniquePlId();
@@ -456,6 +462,12 @@ blockTest('multiplexed fastq with barcode rules', async ({ rawPrj: project, ml: 
   const blockState = project.getBlockState(blockId);
   const stableState = await blockState.awaitStableValue();
 
+  // `sampleGroups.value` is `{}` for MultiplexedFastq by design — the
+  // retentiveOutput in model/src/index.ts returns `undefined` for any dataset
+  // type other than BulkCountMatrix / MultiSampleH5AD / MultiSampleSeurat.
+  // The `ok: true` check confirms the derivation succeeded without throwing,
+  // not its content. The workflow's `multiplexingRules` PColumn emission is
+  // consumed by downstream blocks, not surfaced as a model output here.
   expect(stableState.outputs).toMatchObject({
     fileImports: { ok: true, value: { [r1Handle]: { done: true }, [r2Handle]: { done: true } } },
     sampleGroups: { ok: true, value: { } },

--- a/ui/src/dialogs/ImportSamplesheetDialog.vue
+++ b/ui/src/dialogs/ImportSamplesheetDialog.vue
@@ -219,7 +219,6 @@ function bindingTagError(idx: number): string | undefined {
 
 const importDisabled = computed(() => {
   if (data.fileIdColumnIdx === -1 || data.sampleIdColumnIdx === -1) return true;
-  if (data.bindings.length === 0) return true;
   for (let i = 0; i < data.bindings.length; i++) {
     if (bindingTagError(i)) return true;
   }

--- a/ui/src/dialogs/ImportSamplesheetDialog.vue
+++ b/ui/src/dialogs/ImportSamplesheetDialog.vue
@@ -21,8 +21,7 @@ import {
   extractMetadataFromRow,
   processMetadataColumns,
 } from '../utils/metadata';
-
-const TAG_NAME_RX = /^[A-Za-z0-9]+$/;
+import { defaultBindingsFor, TAG_NAME_RX, type TagBinding } from '../utils/samplesheet-bindings';
 
 const props = defineProps<{
   importCandidate: ImportResult;
@@ -57,51 +56,11 @@ export type SamplesheetImportData = {
 
 const app = useApp();
 
-// Tag-binding row for the dialog: which tag name maps to which column.
-type TagBinding = { tagName: string; columnIdx: number };
-
 const data = reactive({
   fileIdColumnIdx: -1,
   sampleIdColumnIdx: -1,
   bindings: [] as TagBinding[],
 });
-
-function sanitizeTagName(raw: string): string {
-  const cleaned = raw.replace(/[^A-Za-z0-9]/g, '');
-  return cleaned.length > 0 ? cleaned : 'Tag';
-}
-
-/**
- * Build one binding per non-File/non-Sample column, using the column header
- * (sanitized) as the default tag name. For columns that match an
- * already-declared tag (case-insensitive substring), reuse that tag name.
- * Operator removes any binding they don't want as a barcode tag — those
- * columns then flow through the metadata pipeline as before.
- */
-function defaultBindingsFor(
-  ic: ImportResult,
-  fileIdx: number,
-  sampleIdx: number,
-  declaredTags: string[],
-): TagBinding[] {
-  const cols = ic.data.columns;
-  const result: TagBinding[] = [];
-  const taken = new Set<string>();
-  for (let i = 0; i < cols.length; i++) {
-    if (i === fileIdx || i === sampleIdx) continue;
-    const header = cols[i].header;
-    const matchedTag = declaredTags.find((t) => header.toLowerCase().includes(t.toLowerCase()));
-    let tagName = matchedTag ?? (TAG_NAME_RX.test(header) ? header : sanitizeTagName(header));
-    let n = 2;
-    while (taken.has(tagName)) {
-      tagName = `${sanitizeTagName(header) || 'Tag'}${n}`;
-      n++;
-    }
-    taken.add(tagName);
-    result.push({ tagName, columnIdx: i });
-  }
-  return result;
-}
 
 watch(
   () => props.importCandidate,

--- a/ui/src/dialogs/ImportSamplesheetDialog.vue
+++ b/ui/src/dialogs/ImportSamplesheetDialog.vue
@@ -314,9 +314,9 @@ function runImport() {
       :options="sampleColumnOptions"
     />
 
-    <PlAlert v-if="data.bindings.length === 0" type="warn">
-      No barcode tags to import. Every remaining column was removed — close
-      and re-open if that was a mistake.
+    <PlAlert v-if="data.bindings.length === 0" type="info">
+      No barcode columns will be imported — remaining columns will flow to
+      metadata.
     </PlAlert>
 
     <PlRow

--- a/ui/src/utils/samplesheet-bindings.test.ts
+++ b/ui/src/utils/samplesheet-bindings.test.ts
@@ -40,3 +40,45 @@ describe('defaultBindingsFor', () => {
     expect(result).toEqual([]);
   });
 });
+
+describe('defaultBindingsFor — barcode-shaped fallback', () => {
+  it('auto-binds a "Barcode ID" column as BarcodeID when no tags are declared', () => {
+    const result = defaultBindingsFor(
+      ic(['File', 'Sample', 'Barcode ID', 'Condition']),
+      0, 1, [],
+    );
+    expect(result).toEqual([{ tagName: 'BarcodeID', columnIdx: 2 }]);
+  });
+
+  it('matches a typo-style header via the barcode substring (case-insensitive)', () => {
+    const result = defaultBindingsFor(
+      ic(['File', 'Sample', 'syBarcode ID', 'Condition']),
+      0, 1, [],
+    );
+    expect(result).toEqual([{ tagName: 'BarcodeID', columnIdx: 2 }]);
+  });
+
+  it('does not fallback when no barcode-shaped column is present', () => {
+    const result = defaultBindingsFor(
+      ic(['File', 'Sample', 'Condition', 'Treatment']),
+      0, 1, [],
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('does not fallback when declared tags are present', () => {
+    const result = defaultBindingsFor(
+      ic(['File', 'Sample', 'Barcode ID']),
+      0, 1, ['P5'],
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('picks the first matching barcode-shaped column when multiple are present', () => {
+    const result = defaultBindingsFor(
+      ic(['File', 'Sample', 'Barcode A', 'Barcode B']),
+      0, 1, [],
+    );
+    expect(result).toEqual([{ tagName: 'BarcodeID', columnIdx: 2 }]);
+  });
+});

--- a/ui/src/utils/samplesheet-bindings.test.ts
+++ b/ui/src/utils/samplesheet-bindings.test.ts
@@ -39,6 +39,14 @@ describe('defaultBindingsFor', () => {
     );
     expect(result).toEqual([]);
   });
+
+  it('prefers the longer tag when declared tags overlap as substrings', () => {
+    const result = defaultBindingsFor(
+      ic(['File', 'Sample', 'i7_index_column']),
+      0, 1, ['i7', 'i7_index'],
+    );
+    expect(result).toEqual([{ tagName: 'i7_index', columnIdx: 2 }]);
+  });
 });
 
 describe('defaultBindingsFor — barcode-shaped fallback', () => {

--- a/ui/src/utils/samplesheet-bindings.test.ts
+++ b/ui/src/utils/samplesheet-bindings.test.ts
@@ -56,6 +56,22 @@ describe('defaultBindingsFor', () => {
     expect(result).toEqual([{ tagName: 'BarcodeID', columnIdx: 2 }]);
   });
 
+  it('matches a bare "Barcode" header against a declared "BarcodeID" tag (re-import after fallback seeded)', () => {
+    const result = defaultBindingsFor(
+      ic(['File', 'Sample', 'Barcode']),
+      0, 1, ['BarcodeID'],
+    );
+    expect(result).toEqual([{ tagName: 'BarcodeID', columnIdx: 2 }]);
+  });
+
+  it('does not bind a short header to a longer declared tag below the length floor', () => {
+    const result = defaultBindingsFor(
+      ic(['File', 'Sample', 'ID']),
+      0, 1, ['BarcodeID'],
+    );
+    expect(result).toEqual([]);
+  });
+
   it('does not bind every column when a declared tag normalizes to an empty string', () => {
     const result = defaultBindingsFor(
       ic(['File', 'Sample', 'Condition', 'Treatment']),

--- a/ui/src/utils/samplesheet-bindings.test.ts
+++ b/ui/src/utils/samplesheet-bindings.test.ts
@@ -15,17 +15,28 @@ function ic(headers: string[]): ImportResult {
   };
 }
 
-describe('defaultBindingsFor (origin/main behavior — characterization)', () => {
-  // This test locks in the buggy behavior on origin/main so the change in the
-  // next task makes the bug visible as a test failure. Remove or rewrite when
-  // Edit 1 lands.
-  it('CURRENT BUG: binds every non-File / non-Sample column even with no declared tags', () => {
+describe('defaultBindingsFor', () => {
+  it('returns no bindings when no tags are declared (the ticket fix)', () => {
     const result = defaultBindingsFor(
       ic(['File', 'Sample', 'Condition', 'Treatment']),
       0, 1, [],
     );
-    expect(result).toHaveLength(2);
-    expect(result[0]).toEqual({ tagName: 'Condition', columnIdx: 2 });
-    expect(result[1]).toEqual({ tagName: 'Treatment', columnIdx: 3 });
+    expect(result).toEqual([]);
+  });
+
+  it('binds a column whose header matches a declared tag (case-insensitive substring)', () => {
+    const result = defaultBindingsFor(
+      ic(['File', 'Sample', 'P5', 'Condition']),
+      0, 1, ['P5'],
+    );
+    expect(result).toEqual([{ tagName: 'P5', columnIdx: 2 }]);
+  });
+
+  it('returns no binding for unrelated columns even when a tag is declared', () => {
+    const result = defaultBindingsFor(
+      ic(['File', 'Sample', 'Condition', 'Treatment']),
+      0, 1, ['P5'],
+    );
+    expect(result).toEqual([]);
   });
 });

--- a/ui/src/utils/samplesheet-bindings.test.ts
+++ b/ui/src/utils/samplesheet-bindings.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import type { ImportResult } from '../dataimport';
+import { defaultBindingsFor } from './samplesheet-bindings';
+
+function ic(headers: string[]): ImportResult {
+  return {
+    data: {
+      columns: headers.map((header) => ({ header, type: 'String' as const })),
+      rows: [],
+    },
+    missingHeaders: 0,
+    emptyRowsRemoved: 0,
+    malformedRowsRemoved: 0,
+    emptyColumns: 0,
+  };
+}
+
+describe('defaultBindingsFor (origin/main behavior — characterization)', () => {
+  // This test locks in the buggy behavior on origin/main so the change in the
+  // next task makes the bug visible as a test failure. Remove or rewrite when
+  // Edit 1 lands.
+  it('CURRENT BUG: binds every non-File / non-Sample column even with no declared tags', () => {
+    const result = defaultBindingsFor(
+      ic(['File', 'Sample', 'Condition', 'Treatment']),
+      0, 1, [],
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ tagName: 'Condition', columnIdx: 2 });
+    expect(result[1]).toEqual({ tagName: 'Treatment', columnIdx: 3 });
+  });
+});

--- a/ui/src/utils/samplesheet-bindings.test.ts
+++ b/ui/src/utils/samplesheet-bindings.test.ts
@@ -47,6 +47,22 @@ describe('defaultBindingsFor', () => {
     );
     expect(result).toEqual([{ tagName: 'i7_index', columnIdx: 2 }]);
   });
+
+  it('matches a "Barcode ID" header against a declared "BarcodeID" tag (alphanumeric normalization)', () => {
+    const result = defaultBindingsFor(
+      ic(['File', 'Sample', 'Barcode ID']),
+      0, 1, ['BarcodeID'],
+    );
+    expect(result).toEqual([{ tagName: 'BarcodeID', columnIdx: 2 }]);
+  });
+
+  it('does not bind every column when a declared tag normalizes to an empty string', () => {
+    const result = defaultBindingsFor(
+      ic(['File', 'Sample', 'Condition', 'Treatment']),
+      0, 1, ['-'],
+    );
+    expect(result).toEqual([]);
+  });
 });
 
 describe('defaultBindingsFor — barcode-shaped fallback', () => {

--- a/ui/src/utils/samplesheet-bindings.ts
+++ b/ui/src/utils/samplesheet-bindings.ts
@@ -28,11 +28,20 @@ export function defaultBindingsFor(
   // without this, 'i7' shadows 'i7_index' when both are declared.
   const sortedTags = [...declaredTags].sort((a, b) => b.length - a.length);
 
-  // Bind columns matching a declared tag (case-insensitive substring).
+  // Strip non-alphanumeric before matching so a 'BarcodeID' declared tag
+  // resolves against a 'Barcode ID' header on re-import. The empty-string
+  // guard keeps a pathological tag like '-' from substring-matching every
+  // header.
+  const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+  // Bind columns matching a declared tag (alphanumeric, case-insensitive substring).
   for (let i = 0; i < cols.length; i++) {
     if (i === fileIdx || i === sampleIdx) continue;
-    const header = cols[i].header;
-    const matchedTag = sortedTags.find((t) => header.toLowerCase().includes(t.toLowerCase()));
+    const headerNorm = norm(cols[i].header);
+    const matchedTag = sortedTags.find((t) => {
+      const tagNorm = norm(t);
+      return tagNorm !== '' && headerNorm.includes(tagNorm);
+    });
     if (!matchedTag) continue;
     let tagName = matchedTag;
     let n = 2;

--- a/ui/src/utils/samplesheet-bindings.ts
+++ b/ui/src/utils/samplesheet-bindings.ts
@@ -4,6 +4,13 @@ export const TAG_NAME_RX = /^[A-Za-z0-9]+$/;
 
 export type TagBinding = { tagName: string; columnIdx: number };
 
+// Reverse-direction match (tag includes header) needs a header-length floor.
+// A 2-3 char header like 'ID' (norm 'id') would otherwise substring-match
+// every longer declared tag ending in those chars. Four excludes the obvious
+// noise ('id', 'p5', 'p7') while keeping headers like 'Barcode' (7 chars)
+// matching a declared 'BarcodeID' on re-import.
+const MIN_REVERSE_HEADER_LEN = 4;
+
 /**
  * Build one binding per non-File / non-Sample column whose header matches an
  * already-declared barcode tag (case-insensitive substring). Columns that
@@ -35,11 +42,10 @@ export function defaultBindingsFor(
   const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
 
   // Bind columns matching a declared tag (alphanumeric, case-insensitive substring).
-  // Containment is bidirectional so a short header like 'Barcode' (norm 'barcode')
-  // still matches a longer declared tag like 'BarcodeID' (norm 'barcodeid') on
-  // re-import — the asymmetric direction was the failure mode the fresh-dataset
-  // fallback could create. The headerNorm.length floor on the reverse direction
-  // stops noise like a header 'ID' (norm 'id') latching onto 'BarcodeID'.
+  // Containment is bidirectional so a short header like 'Barcode' still matches
+  // a longer declared tag like 'BarcodeID' on re-import — the asymmetric
+  // direction was a failure mode the fresh-dataset fallback could create.
+  // MIN_REVERSE_HEADER_LEN floors the reverse direction.
   for (let i = 0; i < cols.length; i++) {
     if (i === fileIdx || i === sampleIdx) continue;
     const headerNorm = norm(cols[i].header);
@@ -47,7 +53,7 @@ export function defaultBindingsFor(
       const tagNorm = norm(t);
       if (tagNorm === '') return false;
       return headerNorm.includes(tagNorm)
-        || (headerNorm.length >= 4 && tagNorm.includes(headerNorm));
+        || (headerNorm.length >= MIN_REVERSE_HEADER_LEN && tagNorm.includes(headerNorm));
     });
     if (!matchedTag) continue;
     let tagName = matchedTag;

--- a/ui/src/utils/samplesheet-bindings.ts
+++ b/ui/src/utils/samplesheet-bindings.ts
@@ -35,12 +35,19 @@ export function defaultBindingsFor(
   const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
 
   // Bind columns matching a declared tag (alphanumeric, case-insensitive substring).
+  // Containment is bidirectional so a short header like 'Barcode' (norm 'barcode')
+  // still matches a longer declared tag like 'BarcodeID' (norm 'barcodeid') on
+  // re-import — the asymmetric direction was the failure mode the fresh-dataset
+  // fallback could create. The headerNorm.length floor on the reverse direction
+  // stops noise like a header 'ID' (norm 'id') latching onto 'BarcodeID'.
   for (let i = 0; i < cols.length; i++) {
     if (i === fileIdx || i === sampleIdx) continue;
     const headerNorm = norm(cols[i].header);
     const matchedTag = sortedTags.find((t) => {
       const tagNorm = norm(t);
-      return tagNorm !== '' && headerNorm.includes(tagNorm);
+      if (tagNorm === '') return false;
+      return headerNorm.includes(tagNorm)
+        || (headerNorm.length >= 4 && tagNorm.includes(headerNorm));
     });
     if (!matchedTag) continue;
     let tagName = matchedTag;

--- a/ui/src/utils/samplesheet-bindings.ts
+++ b/ui/src/utils/samplesheet-bindings.ts
@@ -24,14 +24,15 @@ export function defaultBindingsFor(
   const result: TagBinding[] = [];
   const taken = new Set<string>();
 
+  // Sort longest-first so overlapping tags match the most specific one:
+  // without this, 'i7' shadows 'i7_index' when both are declared.
+  const sortedTags = [...declaredTags].sort((a, b) => b.length - a.length);
+
   // Bind columns matching a declared tag (case-insensitive substring).
-  // Potential issue: substring match returns first-found in array order. If
-  // declared tags overlap (e.g. ['i7', 'i7_index']) the shorter tag can
-  // shadow the longer one — sort by length desc if this becomes real.
   for (let i = 0; i < cols.length; i++) {
     if (i === fileIdx || i === sampleIdx) continue;
     const header = cols[i].header;
-    const matchedTag = declaredTags.find((t) => header.toLowerCase().includes(t.toLowerCase()));
+    const matchedTag = sortedTags.find((t) => header.toLowerCase().includes(t.toLowerCase()));
     if (!matchedTag) continue;
     let tagName = matchedTag;
     let n = 2;

--- a/ui/src/utils/samplesheet-bindings.ts
+++ b/ui/src/utils/samplesheet-bindings.ts
@@ -10,9 +10,14 @@ export function sanitizeTagName(raw: string): string {
 }
 
 /**
- * Build one binding per non-File / non-Sample column whose header matches
- * an already-declared barcode tag (case-insensitive substring). Columns that
+ * Build one binding per non-File / non-Sample column whose header matches an
+ * already-declared barcode tag (case-insensitive substring). Columns that
  * do not match a declared tag flow through the metadata pipeline.
+ *
+ * On a fresh dataset (no declared tags), as a fallback for the single-
+ * Barcode-ID flow used by demultiplexing blocks, the first column whose
+ * header contains `barcode` (case-insensitive) is auto-bound as a
+ * `BarcodeID` tag.
  */
 export function defaultBindingsFor(
   ic: ImportResult,
@@ -23,6 +28,8 @@ export function defaultBindingsFor(
   const cols = ic.data.columns;
   const result: TagBinding[] = [];
   const taken = new Set<string>();
+
+  // Bind columns matching a declared tag (case-insensitive substring).
   for (let i = 0; i < cols.length; i++) {
     if (i === fileIdx || i === sampleIdx) continue;
     const header = cols[i].header;
@@ -37,5 +44,21 @@ export function defaultBindingsFor(
     taken.add(tagName);
     result.push({ tagName, columnIdx: i });
   }
+
+  // Fallback for the single-Barcode-ID flow: on a fresh dataset (no declared
+  // tags) where the samplesheet has any column whose header contains
+  // `barcode` (case-insensitive), pre-bind the first such column as a
+  // `BarcodeID` tag. Matches the V3 migration's seed convention so
+  // downstream identifiers stay consistent with legacy projects.
+  if (result.length === 0 && declaredTags.length === 0) {
+    for (let i = 0; i < cols.length; i++) {
+      if (i === fileIdx || i === sampleIdx) continue;
+      if (cols[i].header.toLowerCase().includes('barcode')) {
+        result.push({ tagName: 'BarcodeID', columnIdx: i });
+        break;
+      }
+    }
+  }
+
   return result;
 }

--- a/ui/src/utils/samplesheet-bindings.ts
+++ b/ui/src/utils/samplesheet-bindings.ts
@@ -4,11 +4,6 @@ export const TAG_NAME_RX = /^[A-Za-z0-9]+$/;
 
 export type TagBinding = { tagName: string; columnIdx: number };
 
-export function sanitizeTagName(raw: string): string {
-  const cleaned = raw.replace(/[^A-Za-z0-9]/g, '');
-  return cleaned.length > 0 ? cleaned : 'Tag';
-}
-
 /**
  * Build one binding per non-File / non-Sample column whose header matches an
  * already-declared barcode tag (case-insensitive substring). Columns that
@@ -30,6 +25,9 @@ export function defaultBindingsFor(
   const taken = new Set<string>();
 
   // Bind columns matching a declared tag (case-insensitive substring).
+  // Potential issue: substring match returns first-found in array order. If
+  // declared tags overlap (e.g. ['i7', 'i7_index']) the shorter tag can
+  // shadow the longer one — sort by length desc if this becomes real.
   for (let i = 0; i < cols.length; i++) {
     if (i === fileIdx || i === sampleIdx) continue;
     const header = cols[i].header;

--- a/ui/src/utils/samplesheet-bindings.ts
+++ b/ui/src/utils/samplesheet-bindings.ts
@@ -10,11 +10,9 @@ export function sanitizeTagName(raw: string): string {
 }
 
 /**
- * Build one binding per non-File/non-Sample column, using the column header
- * (sanitized) as the default tag name. For columns that match an
- * already-declared tag (case-insensitive substring), reuse that tag name.
- * Operator removes any binding they don't want as a barcode tag — those
- * columns then flow through the metadata pipeline as before.
+ * Build one binding per non-File / non-Sample column whose header matches
+ * an already-declared barcode tag (case-insensitive substring). Columns that
+ * do not match a declared tag flow through the metadata pipeline.
  */
 export function defaultBindingsFor(
   ic: ImportResult,
@@ -29,10 +27,11 @@ export function defaultBindingsFor(
     if (i === fileIdx || i === sampleIdx) continue;
     const header = cols[i].header;
     const matchedTag = declaredTags.find((t) => header.toLowerCase().includes(t.toLowerCase()));
-    let tagName = matchedTag ?? (TAG_NAME_RX.test(header) ? header : sanitizeTagName(header));
+    if (!matchedTag) continue;
+    let tagName = matchedTag;
     let n = 2;
     while (taken.has(tagName)) {
-      tagName = `${sanitizeTagName(header) || 'Tag'}${n}`;
+      tagName = `${matchedTag}${n}`;
       n++;
     }
     taken.add(tagName);

--- a/ui/src/utils/samplesheet-bindings.ts
+++ b/ui/src/utils/samplesheet-bindings.ts
@@ -1,0 +1,42 @@
+import type { ImportResult } from '../dataimport';
+
+export const TAG_NAME_RX = /^[A-Za-z0-9]+$/;
+
+export type TagBinding = { tagName: string; columnIdx: number };
+
+export function sanitizeTagName(raw: string): string {
+  const cleaned = raw.replace(/[^A-Za-z0-9]/g, '');
+  return cleaned.length > 0 ? cleaned : 'Tag';
+}
+
+/**
+ * Build one binding per non-File/non-Sample column, using the column header
+ * (sanitized) as the default tag name. For columns that match an
+ * already-declared tag (case-insensitive substring), reuse that tag name.
+ * Operator removes any binding they don't want as a barcode tag — those
+ * columns then flow through the metadata pipeline as before.
+ */
+export function defaultBindingsFor(
+  ic: ImportResult,
+  fileIdx: number,
+  sampleIdx: number,
+  declaredTags: string[],
+): TagBinding[] {
+  const cols = ic.data.columns;
+  const result: TagBinding[] = [];
+  const taken = new Set<string>();
+  for (let i = 0; i < cols.length; i++) {
+    if (i === fileIdx || i === sampleIdx) continue;
+    const header = cols[i].header;
+    const matchedTag = declaredTags.find((t) => header.toLowerCase().includes(t.toLowerCase()));
+    let tagName = matchedTag ?? (TAG_NAME_RX.test(header) ? header : sanitizeTagName(header));
+    let n = 2;
+    while (taken.has(tagName)) {
+      tagName = `${sanitizeTagName(header) || 'Tag'}${n}`;
+      n++;
+    }
+    taken.add(tagName);
+    result.push({ tagName, columnIdx: i });
+  }
+  return result;
+}


### PR DESCRIPTION
## Bug fix (MILAB-6274 — metadata not imported)

- Extract `defaultBindingsFor` into `ui/src/utils/samplesheet-bindings.ts` (pure refactor; enables unit testing).
- Auto-bind only columns matching a declared `barcodeTag` (case-insensitive substring). Unmatched columns flow to `args.metadata`.
- Drop `bindings.length === 0` from the Import button's `disabled` gate (required corollary — a metadata-only samplesheet correctly produces zero bindings).

## Other

- Fall back to binding the first `barcode`-shaped column as `BarcodeID` on a fresh dataset — restores the one-click Miltenyi flow that the bug fix would otherwise break.
- Sort `declaredTags` by length desc so overlapping tags like `['i7', 'i7_index']` match the most specific one.
- Add a workflow regression test `multiplexed fastq with barcode rules` in `test/src/wf.test.ts`.
- Bump `@platforma-sdk/block-tools` 2.7.15 → 2.8.1 (CI gate).
- Remove unused `sanitizeTagName`.

Tests: 8 unit cases in `samplesheet-bindings.test.ts` + 1 workflow test. UI patch bump.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes MILAB-6274, where the samplesheet importer incorrectly bound every non-File/non-Sample column as a barcode tag, silently dropping metadata columns like `Condition` and `Treatment`. The core fix restricts auto-binding to columns that match an already-declared `barcodeTag`, with a fresh-dataset fallback that auto-binds the first barcode-shaped column as `BarcodeID`.

- Extracts `defaultBindingsFor` into `ui/src/utils/samplesheet-bindings.ts` with alphanumeric normalization and bidirectional substring matching to handle re-import edge cases (`'Barcode ID'` → `'BarcodeID'`, `'Barcode'` → `'BarcodeID'`).
- Drops the `bindings.length === 0` guard from the Import button's `disabled` gate so metadata-only samplesheets can be imported; replaces the misleading warn alert with a neutral info message.
- Adds 8 unit tests and a workflow regression test (`multiplexed fastq with barcode rules`) covering the primary scenarios.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge; it narrows an over-eager auto-bind and the dialog remains the operator's last line of review before data is committed.

The core logic refactor is well-tested (8 unit cases + 1 workflow test), the bidirectional match handles the two known re-import asymmetries, and the metadata-flow path is now correctly gated. The only concern is a false-positive at the 4-char reverse-match boundary (a column called 'Code' matching a declared 'BarcodeID' tag), but this is visible in the dialog and removable by the operator before import.

ui/src/utils/samplesheet-bindings.ts — the 4-char floor in the bidirectional reverse check.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ui/src/utils/samplesheet-bindings.ts | New utility module for default binding logic; bidirectional substring match is sound for BarcodeID/Barcode but the 4-char reverse floor admits 'Code' as a false positive against 'BarcodeID'. |
| ui/src/utils/samplesheet-bindings.test.ts | Good test coverage for the main cases; missing a case at the exact length-4 boundary (e.g., 'Code' vs declared 'BarcodeID') that would expose the reverse-direction false positive. |
| ui/src/dialogs/ImportSamplesheetDialog.vue | Correctly drops the bindings.length === 0 guard from importDisabled, extracts logic to samplesheet-bindings.ts, and replaces the misleading warn alert with a neutral info alert. |
| test/src/wf.test.ts | Adds a regression test for the MultiplexedFastq path with barcodeRules; also cleans up unused ml parameter across existing tests. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[importCandidate prop changes] --> B[Detect File & Sample column indices]
    B --> C[defaultBindingsFor called]

    C --> D{declaredTags.length > 0?}
    D -- Yes --> E[Sort tags longest-first]
    E --> F[For each non-File/non-Sample column]
    F --> G{headerNorm contains tagNorm OR bidirectional reverse match?}
    G -- Match --> H[Add binding tagName=declaredTag]
    G -- No match --> I[Column flows to metadata]
    H --> J[result not empty]
    D -- No --> K[Main loop: result = empty]

    K --> L{Any barcode-shaped column?}
    L -- Yes --> M[Bind first as BarcodeID fallback]
    L -- No --> N[Return empty — metadata-only import]

    J --> O[Operator reviews bindings in dialog]
    M --> O
    N --> O
    O --> P{Import clicked?}
    P -- bindings exist --> Q[Emit barcodes + declaredTags]
    P -- no bindings --> R[Emit empty barcodes, all cols as metadata]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ui/src/dialogs/ImportSamplesheetDialog.vue`, line 317-320 ([link](https://github.com/platforma-open/samples-and-data/blob/98d6c1de7a47784891fc7fbeb0314ca86264dc79/ui/src/dialogs/ImportSamplesheetDialog.vue#L317-L320)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Warning text misleads when bindings are zero by design**

   The message "Every remaining column was removed — close and re-open if that was a mistake" implies the user accidentally deleted all bindings. But the common path after this PR is a metadata-only samplesheet where no columns should be bound (zero bindings is correct). Users who land here intentionally will be confused by the suggestion to "close and re-open". A more neutral message like "No barcode columns will be imported — remaining columns will flow to metadata." avoids the false-alarm tone.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: ui/src/dialogs/ImportSamplesheetDialog.vue
   Line: 317-320

   Comment:
   **Warning text misleads when bindings are zero by design**

   The message "Every remaining column was removed — close and re-open if that was a mistake" implies the user accidentally deleted all bindings. But the common path after this PR is a metadata-only samplesheet where no columns should be bound (zero bindings is correct). Users who land here intentionally will be confused by the suggestion to "close and re-open". A more neutral message like "No barcode columns will be imported — remaining columns will flow to metadata." avoids the false-alarm tone.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
ui/src/utils/samplesheet-bindings.ts:49-50
**Reverse-direction check admits short metadata column names as false barcode matches**

The floor of 4 is too low to filter out common metadata column names like `'Code'` (norm `'code'`, length 4). `'barcodeid'.includes('code')` is `true`, so when a dataset has `barcodeTags: ['BarcodeID']`, a column headed `'Code'` is auto-bound as a `'BarcodeID'` barcode tag. An operator who doesn't notice the pre-filled binding row would import with wrong barcode values. There is no test covering this boundary (the test suite only tests `'ID'` at length 2, not `'Code'` at length 4).

Raising the floor to `>= 5` or to `Math.ceil(tagNorm.length / 2)` would exclude `'code'` while still matching `'Barcode'` (7 chars, the critical re-import case). Alternatively, anchoring the reverse match to a fraction of the tag length rather than a fixed constant would scale better as more tag names are declared.


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["MILAB-6274: soften zero-bindings alert f..."](https://github.com/platforma-open/samples-and-data/commit/3fd32b1e21d838438197f4ae326e336ab6a28279) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33118112)</sub>

<!-- /greptile_comment -->